### PR TITLE
Update to work with Tensorflow 0.11.0rc2

### DIFF
--- a/lstm.py
+++ b/lstm.py
@@ -3,6 +3,7 @@ import pandas as pd
 import tensorflow as tf
 from tensorflow.python.framework import dtypes
 from tensorflow.contrib import learn
+from tensorflow.contrib import layers as tflayers
 
 def x_sin(x):
     return x * np.sin(x)
@@ -99,12 +100,12 @@ def lstm_model(num_units, rnn_layers, dense_layers=None, learning_rate=0.1, opti
 
     def dnn_layers(input_layers, layers):
         if layers and isinstance(layers, dict):
-            return learn.ops.dnn(input_layers,
+            return tflayers.stack(input_layers, tflayers.fully_connected,
                                  layers['layers'],
                                  activation=layers.get('activation'),
                                  dropout=layers.get('dropout'))
         elif layers:
-            return learn.ops.dnn(input_layers, layers)
+            return tflayers.stack(input_layers, tflayers.fully_connected, layers)
         else:
             return input_layers
 


### PR DESCRIPTION
Remove deprecated tensorflow.contrib.learn.rnn.dnn.

Fixes issue #12, #14 and #16.

It at least compiles and runs when I run the 4 notebooks, but I haven't done any more testing beyond that, and am not sure how to confirm that it's working as expected / as it used to (enabling dense layers doesn't seem to increase accuracy). Can someone else help test here?

I did not test the "first if" route through the code (where layers is a dict) because none of the notebooks appear to use that functionality (they all set DENSE_LAYERS to None or [10,10]).

Tested only with Tensorflow 0.11.0rc2, and Python 5.3.2. Backwards compatibility not tested. 