### PR TITLE
Don't prune requirements folder

### DIFF
--- a/traceml/MANIFEST.in
+++ b/traceml/MANIFEST.in
@@ -1,7 +1,6 @@
 global-exclude *.py[cod]
 prune tests
 prune __pycache__
-prune requirements
 include ../README.md
 include ../LICENSE
 include ../CONTRIBUTING.md


### PR DESCRIPTION
`requirements/dev.txt` is used by `setup.py` and thus needs to be part of the sdist tarball.